### PR TITLE
Use longest match when parsing a `sequence-set'

### DIFF
--- a/imap/imapParser.ml
+++ b/imap/imapParser.ml
@@ -472,7 +472,7 @@ sequence-set    = (seq-number / seq-range) *("," sequence-set)
                     ; overlap coalesced to be 4,5,6,7,8,9,10.
 *)
 let sequence_set =
-  let elem = alt (seq_number >>= fun x -> ret (ImapSet.single x)) seq_range in
+  let elem = alt seq_range (seq_number >>= fun x -> ret (ImapSet.single x)) in
   elem >>= fun x ->
   rep (char ',' >> elem) >>= fun xs ->
   ret (List.fold_left ImapSet.union x xs)


### PR DESCRIPTION
For example, "15:16" sequence set was parsed as "15", and
`response_data` parser would succeed on "\* VANISHED 15\r\n", but would
fail on a valid "\* VANISHED 15:16\r\n" response.
