### PR TITLE
Parse envelope address lists without spaces

### DIFF
--- a/lib/imap.ml
+++ b/lib/imap.ml
@@ -706,6 +706,14 @@ module D = struct
     if is_atom_char $ cur d then p_atomf "NIL" $ k [] $ d else
     p_ch '(' (fun d -> if cur d = ')' then readc $ k [] $ d else p (fun x -> loop [x]) d) d
 
+  let p_list_nosp p k d =
+    let rec loop acc d =
+      if cur d = ')' then readc $ k (List.rev acc) $ d else
+      p (fun x -> loop (x :: acc)) $ d
+    in
+    if is_atom_char $ cur d then p_atomf "NIL" $ k [] $ d else
+    p_ch '(' (fun d -> if cur d = ')' then readc $ k [] $ d else p (fun x -> loop [x]) d) d
+
 (*
    CR             =  %x0D
                                   ; carriage return
@@ -1278,12 +1286,12 @@ module D = struct
     p_ch '(' begin
              p_nstring'       @@ fun env_date ->
       p_sp $ p_nstring'       @@ fun env_subject ->
-      p_sp $ p_list p_address @@ fun env_from ->
-      p_sp $ p_list p_address @@ fun env_sender ->
-      p_sp $ p_list p_address @@ fun env_reply_to ->
-      p_sp $ p_list p_address @@ fun env_to ->
-      p_sp $ p_list p_address @@ fun env_cc ->
-      p_sp $ p_list p_address @@ fun env_bcc ->
+      p_sp $ p_list_nosp p_address @@ fun env_from ->
+      p_sp $ p_list_nosp p_address @@ fun env_sender ->
+      p_sp $ p_list_nosp p_address @@ fun env_reply_to ->
+      p_sp $ p_list_nosp p_address @@ fun env_to ->
+      p_sp $ p_list_nosp p_address @@ fun env_cc ->
+      p_sp $ p_list_nosp p_address @@ fun env_bcc ->
       p_sp $ p_nstring'       @@ fun env_in_reply_to ->
       p_sp $ p_nstring'       @@ fun env_message_id ->
       p_ch ')' $


### PR DESCRIPTION
The IMAP spec doesn’t allow spaces between address elements.
Example envelope-to input from Cyrus:

    ``((NIL NIL "undisclosed-recipients" NIL)(NIL NIL NIL NIL))``

The parser trips over the second element:

    IMAP Error: Decode error: Unexpected character '('
    print_objs: internal error, uncaught exception:
                Failure("imap error")

because it expects a space or closing paren. This adds a list
pattern that immediately continues with the address pattern
instead.