### PR TITLE
Assorted improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ setup.log
 *.o
 *.lib
 .gh-pages
+_opam
+.*.swp

--- a/cli/imap_cmdliner.ml
+++ b/cli/imap_cmdliner.ml
@@ -33,7 +33,8 @@ type args = {
   mailbox: string;
 }
 
-let opts server port username password tls mailbox =
+let opts server port username password no_tls mailbox =
+  let tls = not no_tls in
   { server; port; username; password; tls; mailbox}
 
 let server =
@@ -52,16 +53,16 @@ let password =
   let doc = Arg.info ~docv:"PASSWORD" ~doc:"Password" [] in
   Arg.(required & pos 2 (some string) None & doc)
 
-let tls =
-  let doc = "Connect via TLS" in
-  Arg.(value & flag & info ["tls"] ~doc)
+let no_tls =
+  let doc = "Connect via plain-text and disable TLS (use with care)" in
+  Arg.(value & flag & info ["no-tls"] ~doc)
 
 let mailbox =
   let doc = Arg.info ~docv:"MAILBOX" ~doc:"Mailbox to connect to" [] in
   Arg.(required & pos 3 (some string) None & doc)
 
 let client =
-  Term.(const opts $ server $ port $ username $ password $ tls $ mailbox)
+  Term.(const opts $ server $ port $ username $ password $ no_tls $ mailbox)
 
 let connect ?read_only {server; port; username; password; tls; mailbox} =
   Imap.connect server ~tls ?port username password ?read_only mailbox

--- a/cli/imap_cmdliner.ml
+++ b/cli/imap_cmdliner.ml
@@ -1,0 +1,67 @@
+(* The MIT License (MIT)
+  
+   Copyright (c) 2015-2017 Nicolas Ojeda Bar <n.oje.bar@gmail.com>
+   Copyright (c) 2017 Anil Madhavapeddy <anil@recoil.org>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+
+open Cmdliner
+
+type args = {
+  server: string;
+  port: int option;
+  username: string;
+  password: string;
+  tls: bool;
+  mailbox: string;
+}
+
+let opts server port username password tls mailbox =
+  { server; port; username; password; tls; mailbox}
+
+let server =
+  let doc = Arg.info ~docv:"SERVER" ~doc:"Server hostname" [] in
+  Arg.(required & pos 0 (some string) None & doc)
+
+let port =
+  let doc = Arg.info ~docv:"PORT" ~doc:"Server port" ["port"; "p"] in
+  Arg.(value & opt (some int) None & doc)
+
+let username =
+  let doc = Arg.info ~docv:"USERNAME" ~doc:"Username" [] in
+  Arg.(required & pos 1 (some string) None & doc)
+
+let password =
+  let doc = Arg.info ~docv:"PASSWORD" ~doc:"Password" [] in
+  Arg.(required & pos 2 (some string) None & doc)
+
+let tls =
+  let doc = "Connect via TLS" in
+  Arg.(value & flag & info ["tls"] ~doc)
+
+let mailbox =
+  let doc = Arg.info ~docv:"MAILBOX" ~doc:"Mailbox to connect to" [] in
+  Arg.(required & pos 3 (some string) None & doc)
+
+let client =
+  Term.(const opts $ server $ port $ username $ password $ tls $ mailbox)
+
+let connect ?read_only {server; port; username; password; tls; mailbox} =
+  Imap.connect server ~tls ?port username password ?read_only mailbox

--- a/cli/imap_cmdliner.mli
+++ b/cli/imap_cmdliner.mli
@@ -51,6 +51,6 @@ val server : string Cmdliner.Term.t
 val port : int option Cmdliner.Term.t
 val username : string Cmdliner.Term.t
 val password : string Cmdliner.Term.t
-val tls : bool Cmdliner.Term.t
+val no_tls : bool Cmdliner.Term.t
 val mailbox : string Cmdliner.Term.t
 

--- a/cli/imap_cmdliner.mli
+++ b/cli/imap_cmdliner.mli
@@ -1,0 +1,56 @@
+(* The MIT License (MIT)
+  
+   Copyright (c) 2015-2017 Nicolas Ojeda Bar <n.oje.bar@gmail.com>
+   Copyright (c) 2017 Anil Madhavapeddy <anil@recoil.org>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE. *)
+
+(** Cmdliner terms to quickly assemble IMAP command-line interfaces *)
+
+(** {2 IMAP client command line terms} *)
+
+type args = {
+  server: string;
+  port: int option;
+  username: string;
+  password: string;
+  tls: bool;
+  mailbox: string;
+}
+(** Arguments to make an IMAP client connection. *)
+
+val client : args Cmdliner.Term.t
+(** [client] is a {!Cmdliner} term that exposes CLI flags
+    for establishing an outgoing IMAP client connection. *)
+
+val connect : ?read_only:bool -> args -> Imap.t Lwt.t
+(** [connect] will invoke {!Imap.connect} with the arguments
+    passed on the command-line. *)
+
+(** {2 Individual Terms}
+   These can be used individually if the above {!client} term
+   needs to be customised. *)
+
+val server : string Cmdliner.Term.t
+val port : int option Cmdliner.Term.t
+val username : string Cmdliner.Term.t
+val password : string Cmdliner.Term.t
+val tls : bool Cmdliner.Term.t
+val mailbox : string Cmdliner.Term.t
+

--- a/cli/jbuild
+++ b/cli/jbuild
@@ -1,0 +1,6 @@
+(jbuild_version 1)
+
+(library
+ ((name imap_cmdliner)
+  (public_name imap.cmdliner)
+  (libraries (imap cmdliner))))

--- a/examples/jbuild
+++ b/examples/jbuild
@@ -1,9 +1,9 @@
 (jbuild_version 1)
 
 (executables
- ((names (wait_mail minimutt))
-  (libraries (cmdliner imap))))
+ ((names (wait_mail minimutt mailinglist))
+  (libraries (imap_cmdliner))))
 
 (alias
  ((name examples)
-  (deps (wait_mail.exe minimutt.exe))))
+  (deps (wait_mail.exe minimutt.exe mailinglist.exe))))

--- a/examples/mailinglist.ml
+++ b/examples/mailinglist.ml
@@ -1,0 +1,40 @@
+(* this code is in the public domain *)
+
+(** List all the mailing lists in a folder *)
+
+open Lwt.Infix
+module C = Imap_cmdliner
+
+let () =
+  Printexc.record_backtrace true
+
+let list opts =
+  Imap_cmdliner.connect ~read_only:true opts >>= fun imap ->
+  Imap.uid_search imap Imap.Search.all >>= fun (l, _) ->
+  let h = Hashtbl.create 17 in
+  Lwt_list.iter_s (fun (uid : Imap.uid) ->
+      Imap.(uid_fetch imap [uid] Fetch.[body_section ~section:(header_fields ["list-id"]) ()]) |>
+      Lwt_stream.iter (function
+      | _, Imap.Fetch.{body_section = [_, Some b]; _} -> Hashtbl.replace h b ()
+      | _ -> ())
+    ) l >>= fun () ->
+  (* TODO: process the list-id header via MrMime *)
+  Hashtbl.iter (fun k () -> Printf.printf "%s\n" k) h;
+  Lwt.return_unit
+
+let list opts = Lwt_main.run (list opts)
+
+open Cmdliner
+
+(* let debug = *)
+(*   let doc = Arg.info ~doc:"Show debug info" ["debug"; "d"] in *)
+(*   Arg.(value & flag doc) *)
+
+let main =
+  Term.(pure list $ C.client),
+  Term.info "minimutt"
+
+let () =
+  match Term.eval ~catch:true main with
+  | `Ok _ | `Version | `Help -> ()
+  | `Error _ -> exit 1

--- a/examples/wait_mail.ml
+++ b/examples/wait_mail.ml
@@ -16,9 +16,10 @@
     server which can be quite instructive. *)
 
 open Lwt.Infix
+module C = Imap_cmdliner
 
-let wait_mail server ?port username password mailbox =
-  Imap.connect server ?port username password ~read_only:true mailbox >>= fun imap ->
+let wait_mail opts =
+  C.connect opts >>= fun imap ->
   let rec loop () =
     let uidnext =
       match Imap.uidnext imap with
@@ -40,37 +41,17 @@ let wait_mail server ?port username password mailbox =
   in
   loop ()
 
-let wait_mail server port username password mailbox =
-  Lwt_main.run (wait_mail server ?port username password mailbox)
+let wait_mail opts =
+  Lwt_main.run (wait_mail opts)
 
 open Cmdliner
-
-let server =
-  let doc = Arg.info ~docv:"SERVER" ~doc:"Server hostname" [] in
-  Arg.(required & pos 0 (some string) None & doc)
-
-let port =
-  let doc = Arg.info ~docv:"PORT" ~doc:"Server port" ["port"; "p"] in
-  Arg.(value & opt (some int) None & doc)
-
-let username =
-  let doc = Arg.info ~docv:"USERNAME" ~doc:"Username" [] in
-  Arg.(required & pos 1 (some string) None & doc)
-
-let password =
-  let doc = Arg.info ~docv:"PASSWORD" ~doc:"Password" [] in
-  Arg.(required & pos 2 (some string) None & doc)
-
-let mailbox =
-  let doc = Arg.info ~docv:"MAILBOX" ~doc:"Mailbox to watch" [] in
-  Arg.(required & pos 3 (some string) None & doc)
 
 (* let debug = *)
 (*   let doc = Arg.info ~doc:"Show debug info" ["debug"; "d"] in *)
 (*   Arg.(value & flag doc) *)
 
 let main =
-  Term.(pure wait_mail $ server $ port $ username $ password $ mailbox),
+  Term.(pure wait_mail $ C.client),
   Term.info "wait_mail"
 
 let () =

--- a/imap.install
+++ b/imap.install
@@ -10,6 +10,15 @@ lib: [
   "_build/install/default/lib/imap/imap.cmxa"
   "_build/install/default/lib/imap/imap.a"
   "_build/install/default/lib/imap/imap.cmxs"
+  "_build/install/default/lib/imap/cmdliner/imap_cmdliner.cmi" {"cmdliner/imap_cmdliner.cmi"}
+  "_build/install/default/lib/imap/cmdliner/imap_cmdliner.cmx" {"cmdliner/imap_cmdliner.cmx"}
+  "_build/install/default/lib/imap/cmdliner/imap_cmdliner.cmt" {"cmdliner/imap_cmdliner.cmt"}
+  "_build/install/default/lib/imap/cmdliner/imap_cmdliner.cmti" {"cmdliner/imap_cmdliner.cmti"}
+  "_build/install/default/lib/imap/cmdliner/imap_cmdliner.mli" {"cmdliner/imap_cmdliner.mli"}
+  "_build/install/default/lib/imap/cmdliner/imap_cmdliner.cma" {"cmdliner/imap_cmdliner.cma"}
+  "_build/install/default/lib/imap/cmdliner/imap_cmdliner.cmxa" {"cmdliner/imap_cmdliner.cmxa"}
+  "_build/install/default/lib/imap/cmdliner/imap_cmdliner.a" {"cmdliner/imap_cmdliner.a"}
+  "_build/install/default/lib/imap/cmdliner/imap_cmdliner.cmxs" {"cmdliner/imap_cmdliner.cmxs"}
 ]
 doc: [
   "_build/install/default/doc/imap/README.md"

--- a/imap.install
+++ b/imap.install
@@ -11,9 +11,6 @@ lib: [
   "_build/install/default/lib/imap/imap.a"
   "_build/install/default/lib/imap/imap.cmxs"
 ]
-bin: [
-  "_build/install/default/bin/mlsync" {"mlsync"}
-]
 doc: [
   "_build/install/default/doc/imap/README.md"
   "_build/install/default/doc/imap/LICENSE"

--- a/imap.opam
+++ b/imap.opam
@@ -6,14 +6,15 @@ dev-repo: "https://www.github.com/nojb/ocaml-imap.git"
 bug-reports: "https://www.github.com/nojb/ocaml-imap/issues"
 license: "MIT"
 depends: [
-  "jbuilder" {build}
+  "jbuilder" {build & >="1.0+beta12"}
   "base64" {>= "2.0.0"}
   "uutf"
   "angstrom"
   "sexplib"
   "ppx_sexp_conv" {build}
   "lwt"
-  "lwt_ssl"
+  "tls"
+  "ptime"
 ]
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]

--- a/imap.opam
+++ b/imap.opam
@@ -15,6 +15,7 @@ depends: [
   "lwt"
   "tls"
   "ptime"
+  "cmdliner"
 ]
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]

--- a/lib/imap.ml
+++ b/lib/imap.ml
@@ -115,7 +115,7 @@ module Mutf7 = struct
         let str = String.sub s i (j - i) and buf = Buffer.create 32 in
         recode ~encoding:`UTF_8 `UTF_16BE (`String str) (`Buffer buf);
         let str = B64.encode ~pad:false (Buffer.contents buf) in
-        replace str '/' ',';
+        replace (Bytes.of_string str) '/' ',';
         Buffer.add_string b str; Buffer.add_char b '-'
       in
       let rec loop i =
@@ -153,7 +153,7 @@ module Mutf7 = struct
           match s.[i] with
           | '-' ->
               let str = String.sub s start (i - start) in
-              replace str ',' '/';
+              replace (Bytes.of_string str) ',' '/';
               let str = B64.decode str in (* FIXME do we need to pad it with "===" ? *)
               recode ~encoding:`UTF_16BE `UTF_8 (`String str) (`Buffer b);
               a (i + 1)
@@ -1942,7 +1942,6 @@ open Lwt.Infix
 
 type t =
   {
-    sock: Lwt_ssl.socket;
     ic: Lwt_io.input_channel;
     oc: Lwt_io.output_channel;
 
@@ -1963,11 +1962,8 @@ type t =
     mutable stop_poll: (unit -> unit) option;
   }
 
-let create_connection sock unconsumed =
-  let ic = Lwt_ssl.in_channel_of_descr sock in
-  let oc = Lwt_ssl.out_channel_of_descr sock in
+let create_connection (ic,oc) unconsumed =
   {
-    sock;
     ic;
     oc;
 
@@ -2377,18 +2373,12 @@ let _enable imap caps =
   let format = E.(str "ENABLE" ++ list capability caps) in
   run imap format () (fun _ r _ -> r)
 
-let () =
-  Ssl.init ()
-
-let connect server ?(port = 993) username password ?read_only mailbox =
-  let ctx = Ssl.create_context Ssl.TLSv1_2 Ssl.Client_context in
-  let sock = Lwt_unix.socket Lwt_unix.PF_INET Lwt_unix.SOCK_STREAM 0 in
-  Lwt_unix.gethostbyname server >>= fun he ->
-  let addr = Lwt_unix.ADDR_INET (he.Unix.h_addr_list.(0), port) in
-  Lwt_unix.connect sock addr >>= fun () ->
-  Lwt_ssl.ssl_connect sock ctx >>= fun sock ->
+let connect host ?(port = 993) username password ?read_only mailbox =
+  X509_lwt.authenticator `No_authentication_I'M_STUPID >>= fun authenticator ->
+  let config = Tls.Config.client ~authenticator () in
+  Tls_lwt.connect_ext config (host, port) >>= fun (ic,oc) ->
   let imap =
-    create_connection sock {A.buf = Bigarray.Array1.create Bigarray.char Bigarray.c_layout 0; off = 0; len = 0}
+    create_connection (ic,oc) {A.buf = Bigarray.Array1.create Bigarray.char Bigarray.c_layout 0; off = 0; len = 0}
   in
   recv imap >>= function
   | R.Untagged _ ->
@@ -2399,4 +2389,6 @@ let connect server ?(port = 993) username password ?read_only mailbox =
       Lwt.fail (Failure "unexpected response")
 
 let disconnect imap =
-  logout imap >>= fun () -> Lwt_ssl.ssl_shutdown imap.sock
+  logout imap >>= fun () ->
+  Lwt_io.close imap.oc >>= fun () ->
+  Lwt_io.close imap.ic

--- a/lib/imap.mli
+++ b/lib/imap.mli
@@ -492,7 +492,7 @@ val uidvalidity: t -> uid option
 
 val highestmodseq: t -> modseq option
 
-val connect: string -> ?port:int -> string -> string -> ?read_only:bool -> string -> t Lwt.t
+val connect: string -> ?tls:bool -> ?port:int -> string -> string -> ?read_only:bool -> string -> t Lwt.t
 (** [connect server username password mailbox]. *)
 
 val disconnect: t -> unit Lwt.t

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -5,4 +5,4 @@
   (public_name imap)
   (wrapped false)
   (preprocess (pps (ppx_sexp_conv)))
-  (libraries (uutf base64 sexplib angstrom ssl lwt lwt_ssl))))
+  (libraries (uutf base64 sexplib angstrom lwt tls.lwt))))


### PR DESCRIPTION
Apologies for putting these into a single pull request -- I can break this up if easier or if you only want some of the changes.

- switch to ocaml-tls to make installation easier + remove dependency on openssl
- add a Imap_cmdliner utility library to pull the CLI logic into one place
- make tls optional in the Imap connection library
- add a mailinglist example that lists remote list-id headers. Very rudimentary, still working on the MrMIME integration.