### PR TITLE
respect updated capabilities from tagged response

### DIFF
--- a/lib/imap.ml
+++ b/lib/imap.ml
@@ -244,6 +244,10 @@ let run imap format res process =
         | res ->
             loop res
         end
+    | Tagged (_, OK (Some (CAPABILITY caps), _)) ->
+        imap.capabilities <- caps;
+        imap.tag <- imap.tag + 1;
+        Lwt.return res
     | Tagged _ ->
         imap.tag <- imap.tag + 1;
         Lwt.return res


### PR DESCRIPTION
Before auth, certain servers (e. g. Cyrus) announce a brief list
of auth-related caps which is then replaced by the full list
after authentication:

    * OK [CAPABILITY IMAP4rev1 LITERAL+ ID ENABLE AUTH=CRAM-MD5 AUTH=PLAIN AUTH=GSSAPI AUTH=LOGIN AUTH=DIGEST-MD5 SASL-IR] mail.example.com server ready
    1 login hans-dampf test1234
    1 OK [CAPABILITY IMAP4rev1 LITERAL+ ID ENABLE ACL ... AUTH=CRAM-MD5 AUTH=PLAIN AUTH=GSSAPI AUTH=LOGIN AUTH=DIGEST-MD5 COMPRESS=DEFLATE IDLE] User logged in SESSIONID=<mail.example.com-11111-2222222222-3>

At present, ocaml-imap will only consider capabilities from the untagged
initial response so when IDLE is missing from that list, it currently
bails out:

    main_loop_lwtwrap: internal error, uncaught exception:
                       (Failure "IDLE not supported")

Prevent that by updating the capabilities from the tagged
response.

Signed-off-by: Philipp Gesang <phg@phi-gamma.net>